### PR TITLE
Optimize memory management to prevent leaks

### DIFF
--- a/src/Http/Middleware/LeverRateStore.php
+++ b/src/Http/Middleware/LeverRateStore.php
@@ -3,6 +3,7 @@
 namespace Bluelightco\LeverPhp\Http\Middleware;
 
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 use Spatie\GuzzleRateLimiterMiddleware\Store;
 
 /**
@@ -46,8 +47,8 @@ class LeverRateStore implements Store
 
         // calculate the size of the data
         if ($this->getCacheSize($data) > $this->maxCacheSize) {
-            // If the size exceeds the maxCacheSize, remove the oldest timestamp
-            array_shift($data);
+            // Log a warning instead of removing the oldest timestamp
+            Log::warning("Rate limit exceeded: Cache size for '{$this->cacheKey}' has exceeded the configured limit of {$this->maxCacheSize} bytes.");
         }
 
         // Store the updated data back into the cache

--- a/src/Http/Middleware/LeverRateStore.php
+++ b/src/Http/Middleware/LeverRateStore.php
@@ -25,73 +25,37 @@ class LeverRateStore implements Store
 
     public function get(): array
     {
-        $data = [];
-        $part = 1;
+        // Retrieve the entire data from cache
+        $data = Cache::get($this->cacheKey, []);
 
-        // Retrieve and merge all parts
-        while (Cache::has($this->getCacheKey($part))) { // Check if the part exists
-            $partData = Cache::get($this->getCacheKey($part), []); // Retrieve the part data
-            $data = array_merge($data, $partData); // Merge the part data with the main data
-            $part++; // Move to the next part
-        }
+        // Filter out any timestamps that are older than the cacheTtl
+        $filteredData = array_filter($data, function ($timestamp) {
+            return $timestamp >= now()->timestamp - $this->cacheTtl;
+        });
 
-        return $data;
+        return $filteredData;
     }
 
     public function push(int $timestamp, int $limit)
     {
-        // Retrieve current data
+        // Retrieve the current filtered data
         $data = $this->get();
+
+        // Add the new timestamp
         $data[] = $timestamp;
 
-        // Split data into parts and store each part separately
-        $parts = $this->splitDataIntoParts($data);
-
-        // Store each part in the cache with separate keys
-        foreach ($parts as $index => $partData) {
-            Cache::put($this->getCacheKey($index + 1), $partData, $this->cacheTtl);
+        // calculate the size of the data
+        if ($this->getCacheSize($data) > $this->maxCacheSize) {
+            // If the size exceeds the maxCacheSize, remove the oldest timestamp
+            array_shift($data);
         }
 
-        // Remove any leftover parts that may have been left from previous larger dataset
-        $this->cleanupExtraParts(count($parts) + 1);
-    }
-
-    private function splitDataIntoParts(array $data): array
-    {
-        $parts = [];
-        $currentPart = [];
-
-        foreach ($data as $item) {
-            $currentPart[] = $item;
-            if ($this->getCacheSize($currentPart) > $this->maxCacheSize) {
-                array_pop($currentPart); // Remove the last item that caused the size to exceed
-                $parts[] = $currentPart; // Store the current part in the parts array
-                $currentPart = [$item]; // Start a new part with the last item that was removed
-            }
-        }
-
-        if (! empty($currentPart)) {
-            $parts[] = $currentPart; // Store the current part in the parts array
-        }
-
-        return $parts;
-    }
-
-    private function getCacheKey(int $part): string
-    {
-        return $this->cacheKey.':'.$part;
+        // Store the updated data back into the cache
+        Cache::put($this->cacheKey, $data, $this->cacheTtl);
     }
 
     private function getCacheSize(array $data): int
     {
         return strlen(serialize($data));
-    }
-
-    private function cleanupExtraParts(int $startPart)
-    {
-        while (Cache::has($this->getCacheKey($startPart))) {
-            Cache::forget($this->getCacheKey($startPart));
-            $startPart++;
-        }
     }
 }


### PR DESCRIPTION
### Description of the Change

This commit implements a custom cache `Store` for the Guzzle rate limiter middleware (`RateLimiterMiddleware` from Spatie). The custom `Store` leverages a caching system (such as Redis or DynamoDB) to efficiently manage request timestamps, thereby preventing excessive memory usage and potential memory leaks.

The implementation focuses on maintaining an optimized array of timestamps, filtering out outdated entries that are no longer relevant based on the configured time limit. This ensures that only necessary data is retained in memory, optimizing resource usage.

### Example of Memory Storage

When the rate limiter is in operation, the `Store` would hold an array of timestamps corresponding to the times when requests were made. For example:

- **Initial State**: The store might start with an empty array, `[]`.
- **After First Request**: The array could become `[1627590000]` (where `1627590000` is a Unix timestamp).
- **After Subsequent Requests**: The array could evolve to `[1627590000, 1627590005, 1627590010]`, where each entry represents the time at which a request was made.

If the rate limit is set to allow 10 requests per minute, the `Store` will continuously check and remove timestamps that are older than 300 seconds (5 minutes) from the current time. This filtering keeps the array size manageable and avoids memory bloat.

For instance:

- **After 2 Minutes**: Older timestamps, like `1627590000`, might be removed if they fall outside the 5-minutes window, leaving an array such as `[1627590060, 1627590065]`.

### Technical Notes

- **Memory Management**: The custom `Store` filters out old timestamps that are no longer within the configured time window, reducing the risk of memory leaks by releasing unnecessary memory.
- **Flexibility**: The implementation allows for the use of different caching systems, providing flexibility to adapt to the application’s existing infrastructure.
