### PR TITLE
feat: preserve HTTP status and response body on client errors

### DIFF
--- a/src/Http/Client/LeverClient.php
+++ b/src/Http/Client/LeverClient.php
@@ -2,6 +2,7 @@
 
 namespace Bluelightco\LeverPhp\Http\Client;
 
+use Bluelightco\LeverPhp\Http\Exceptions\LeverApiException;
 use Bluelightco\LeverPhp\Http\Middleware\LeverRateStore;
 use Bluelightco\LeverPhp\Http\Middleware\QueryStringCleanerMiddleware;
 use Bluelightco\LeverPhp\Http\Responses\ApiResponse;
@@ -14,7 +15,6 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\LazyCollection;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
-use RuntimeException;
 use Spatie\GuzzleRateLimiterMiddleware\RateLimiterMiddleware;
 use Spatie\GuzzleRateLimiterMiddleware\Store;
 
@@ -470,6 +470,14 @@ class LeverClient
 
     private function handleException(Exception $e, string $method, string $endpoint, array $options = []): void
     {
+        $statusCode = null;
+        $responseBody = null;
+
+        if ($e instanceof ClientException && $e->getResponse()) {
+            $statusCode = $e->getResponse()->getStatusCode();
+            $responseBody = (string) $e->getResponse()->getBody();
+        }
+
         Log::error("HTTP $method error: ".$e->getMessage(), [
             'message' => $e->getMessage(),
             'package_context' => [
@@ -477,11 +485,16 @@ class LeverClient
                 'method' => $method,
                 'endpoint' => $endpoint,
                 'options' => json_encode($options),
-                'response' => ($e instanceof ClientException ? ($e->getResponse() ? $e->getResponse()->getBody()->getContents() : null) : null),
+                'response' => $responseBody,
             ],
             'exception' => $e,
         ]);
 
-        throw new RuntimeException("Error executing HTTP $method. Please check the logs for more details.");
+        throw new LeverApiException(
+            "Error executing HTTP $method. Please check the logs for more details.",
+            $statusCode,
+            $responseBody,
+            $e,
+        );
     }
 }

--- a/src/Http/Exceptions/LeverApiException.php
+++ b/src/Http/Exceptions/LeverApiException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Bluelightco\LeverPhp\Http\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+class LeverApiException extends RuntimeException
+{
+    public function __construct(
+        string $message,
+        private readonly ?int $statusCode = null,
+        private readonly ?string $responseBody = null,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, $statusCode ?? 0, $previous);
+    }
+
+    public function getStatusCode(): ?int
+    {
+        return $this->statusCode;
+    }
+
+    public function getResponseBody(): ?string
+    {
+        return $this->responseBody;
+    }
+
+    public function isClientError(): bool
+    {
+        return $this->statusCode !== null && $this->statusCode >= 400 && $this->statusCode < 500;
+    }
+
+    public function isServerError(): bool
+    {
+        return $this->statusCode !== null && $this->statusCode >= 500 && $this->statusCode < 600;
+    }
+}

--- a/tests/OpportunitiesTest.php
+++ b/tests/OpportunitiesTest.php
@@ -2,6 +2,7 @@
 
 namespace Bluelightco\LeverPhp\Tests;
 
+use Bluelightco\LeverPhp\Http\Exceptions\LeverApiException;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\LazyCollection;
 use RuntimeException;
@@ -127,6 +128,24 @@ class OpportunitiesTest extends TestCase
             'opportunities',
             (string) $this->container[0]['request']->getUri()
         );
+    }
+
+    /** @test */
+    public function client_error_exposes_status_and_response_body()
+    {
+        $body = '{"code":"BadRequestError","message":"Input HTML is not valid."}';
+        $this->mockHandler->append(new Response(400, [], $body));
+
+        try {
+            $this->lever->opportunities()->create(['name' => 'x']);
+            $this->fail('Expected LeverApiException was not thrown.');
+        } catch (LeverApiException $e) {
+            $this->assertSame(400, $e->getStatusCode());
+            $this->assertSame($body, $e->getResponseBody());
+            $this->assertTrue($e->isClientError());
+            $this->assertFalse($e->isServerError());
+            $this->assertInstanceOf(\GuzzleHttp\Exception\ClientException::class, $e->getPrevious());
+        }
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,6 +26,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->mockHandler = new MockHandler();
 
         $this->container = [];


### PR DESCRIPTION
## Summary
- Introduces `LeverApiException` (extends `RuntimeException`) that carries `statusCode`, `responseBody`, and `isClientError()/isServerError()` helpers.
- `handleException` now throws this typed exception with the original Guzzle exception chained as `$previous`.
- Callers can now distinguish transient 5xx errors (retryable) from permanent 4xx errors (fail fast) and access the Lever error payload for user-facing messaging.

## Why
Downstream apps (e.g. `spot`) were retrying 4xx errors seven times under exponential backoff because the rewrapped `RuntimeException` carried no status. This produced hundreds of Bugsnag events for a single malformed posting and gave admins no actionable error message.

## Backward compatibility

**Safe:**
- `catch (\RuntimeException $e)` still catches — `LeverApiException extends RuntimeException`.
- Exception message string is unchanged.
- Log output is unchanged.
- `catch (\Exception $e)` / `catch (\Throwable $e)` still works.

**Minor behavior changes** (suggest tagging as **v1.1.0**, not a patch):
- `$e->getCode()` — was always `0`; now returns the HTTP status (e.g. `400`, `503`) for `ClientException` paths.
- `$e->getPrevious()` — was always `null`; now returns the underlying Guzzle `ClientException`.

Real-world impact should be zero unless a consumer explicitly checks `getCode() === 0` or `getPrevious() === null`, but these are observable changes, hence minor (not patch) bump.

## Test plan
- [x] `vendor/bin/phpunit` — all 16 tests pass
- [x] New test asserts status code, response body, `isClientError()`, and chained previous exception on a 400 response
- [x] Pre-existing `fail_to_create_opportunity_when_no_perform_as_parameter_included` still passes