### PR TITLE
fix: strip multi-digit array indices from query string

### DIFF
--- a/src/Http/Client/LeverClient.php
+++ b/src/Http/Client/LeverClient.php
@@ -161,7 +161,7 @@ class LeverClient
     private function prepareOptions(array $body): array
     {
         if (isset($this->options['query'])) {
-            $this->options['query'] = preg_replace('/%5B[0-9]%5D/', '',
+            $this->options['query'] = preg_replace('/%5B\d+%5D/', '',
                 http_build_query($this->options['query'])
             );
         }

--- a/src/Http/Middleware/QueryStringCleanerMiddleware.php
+++ b/src/Http/Middleware/QueryStringCleanerMiddleware.php
@@ -12,7 +12,7 @@ class QueryStringCleanerMiddleware
             return function (RequestInterface $request, array $options) use ($handler) {
                 $query = $request->getUri()->getQuery();
                 $request = $request->withUri(
-                    $request->getUri()->withQuery(preg_replace('/%5B[0-9]%5D/', '', $query)),
+                    $request->getUri()->withQuery(preg_replace('/%5B\d+%5D/', '', $query)),
                     true
                 );
 

--- a/tests/OpportunitiesTest.php
+++ b/tests/OpportunitiesTest.php
@@ -249,6 +249,35 @@ class OpportunitiesTest extends TestCase
     }
 
     /** @test */
+    public function retrieve_opportunities_with_more_than_ten_postings_strips_all_array_indices()
+    {
+        // Regression: QueryStringCleanerMiddleware and prepareOptions() previously
+        // used preg_replace('/%5B[0-9]%5D/', ...) which only stripped single-digit
+        // indices ([0]-[9]). Calling posting() 11+ times left posting_id[10]+ in
+        // the URL, producing malformed query strings that Lever rejects.
+        $this->mockHandler->append(new Response(200, [], '{"data": {}}'));
+
+        $ids = [];
+        $client = $this->lever->opportunities();
+        for ($i = 0; $i < 12; $i++) {
+            $id = sprintf('00000000-0000-0000-0000-%012d', $i + 1);
+            $ids[] = $id;
+            $client->posting($id);
+        }
+        $client->fetch();
+
+        $url = (string) $this->container[0]['request']->getUri();
+
+        $this->assertStringNotContainsString('%5B', $url, 'URL must not contain array brackets');
+        $this->assertStringNotContainsString('posting_id[', urldecode($url), 'URL must not contain array indices');
+        $this->assertEquals(12, substr_count($url, 'posting_id='));
+
+        foreach ($ids as $id) {
+            $this->assertStringContainsString('posting_id='.$id, $url);
+        }
+    }
+
+    /** @test */
     public function check_archived_reason_is_added_correctly_to_body()
     {
         $this->mockHandler->append(new Response(200, [], '{"data": {}}'));


### PR DESCRIPTION
## Problem

`QueryStringCleanerMiddleware::buildQuery()` and `LeverClient::prepareOptions()` both use:

```php
preg_replace('/%5B[0-9]%5D/', '', $query)
```

That pattern matches `%5B` + **exactly one digit** + `%5D`, so it strips `%5B0%5D` through `%5B9%5D` but leaves `%5B10%5D`, `%5B11%5D`, ... intact.

When a caller chains the same builder method more than 10 times, e.g.:

```php
$client = $lever->opportunities()->performAs($userId);
foreach ($postingIds as $id) {           // 12 posting IDs
    $client->posting($id);
}
$client->fetch();
```

`http_build_query()` indexes the array, the regex strips the first ten, and the final URL is a mix of clean and array-indexed parameters:

```
opportunities
  ?posting_id=...&posting_id=...&...&posting_id=...   ← first 10 cleaned
  &posting_id%5B10%5D=...&posting_id%5B11%5D=...      ← left behind
```

Lever's API rejects these requests, causing downstream production errors.

## Fix

Switch both regexes to `/%5B\d+%5D/` so any numeric index is stripped regardless of digit count. Behavior for batches ≤10 is unchanged.

## Test

Added `OpportunitiesTest::retrieve_opportunities_with_more_than_ten_postings_strips_all_array_indices`, which calls `->posting()` 12 times and asserts:
- No `%5B` (URL-encoded `[`) anywhere in the URL
- `posting_id[` (decoded form) does not appear
- Exactly 12 `posting_id=` parameters
- Each provided UUID is present

I verified the new test **fails** against the old single-digit regex and **passes** with the multi-digit fix. Existing test suite (17 tests, 56 assertions) remains green.

## Downstream context

Found while debugging Bugsnag errors in a Laravel app that batches up to ~30 `posting_id` parameters in a single `opportunities` request. The application now bypasses the fluent builder as a workaround; once this fix is released we can drop the workaround.